### PR TITLE
Prevent completion block from being called twice when there is an error

### DIFF
--- a/LPLivePhotoGenerator/LPLivePhotoGenerator/LPLivePhoto.swift
+++ b/LPLivePhotoGenerator/LPLivePhotoGenerator/LPLivePhoto.swift
@@ -34,6 +34,7 @@ public class LPLivePhoto {
         }) { (success: Bool, error: Error?) in
             if let error = error {
                 completion(self, LPError.writeToPhotoLibraryFailed(error.localizedDescription))
+                return
             }
             completion(self, nil)
         }


### PR DESCRIPTION
### Steps to Reproduce:

Deny Permission for Photo Library and try to save a LivePhoto.
The `completion` - block will be triggered twice, once with the Error and once without.

This is unexpected.

### Fix:

After there was an error detected we call the `completion` - block with the error and return, therefore no second `completion` is triggered.